### PR TITLE
Revert "BoBc-43 Hide bottom labels in statistics chart (#44)"

### DIFF
--- a/src/components/StatisticsChart.jsx
+++ b/src/components/StatisticsChart.jsx
@@ -35,9 +35,6 @@ class StatisticsChart extends React.Component {
                 animation: false,
                 legend: false,
                 scales: {
-                    xAxis: {
-                        display: false
-                    },
                     xAxes: [{
                         ticks: {
                             display: false


### PR DESCRIPTION
This reverts commit 76a6335093ebb2bce3a4a80186726c8f48c0838d.